### PR TITLE
Add CLI for vim motions via ChatGPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,21 @@ A small end-to-end pipeline that **generates synthetic training data, fine-tunes
 | **`vim-tutor-fintuning.ipynb`** | Fine-tunes *Qwen-2.5-0.5B-instruct* and *Qwen-2.5-7B-instruct*  with 4-bit LoRA on the generated data. Fully reproducible on Kaggle or a single 16 GB GPU. |
 | **`benchmark.ipynb`** | Compares fintuned LLMs with ChatGPT and deepseek. Produces per-model Accuracy & Avg. Levenshtein distance. |
 | **`analysis.ipynb`** | Tiny notebook that loads `Model_Performance_Summary.csv` and surfaces “top-N” tables for quick inspection. |
+
+## Vim Motion CLI
+
+`vim_motion_cli.py` provides a small terminal helper that queries ChatGPT 4.1 using the extended prompt in `extended_prompt.txt`.
+
+### Example
+
+```bash
+OPENAI_API_KEY=your-key python vim_motion_cli.py "delete to end of line"
+```
+
+Run without arguments to enter an interactive shell:
+
+```bash
+OPENAI_API_KEY=your-key python vim_motion_cli.py
+Describe motion> delete to end of line
+Motion: d$
+```

--- a/vim_motion_cli.py
+++ b/vim_motion_cli.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Interactive CLI for Vim motions via ChatGPT 4.1."""
+import argparse
+import os
+from openai import OpenAI
+
+
+def ask_motion(client: OpenAI, prompt_template: str, model: str, description: str) -> str:
+    """Send description to ChatGPT and return the Vim motion."""
+    prompt = prompt_template.format(description=description)
+    response = client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.0,
+        max_tokens=20,
+        n=1,
+    )
+    return response.choices[0].message.content.strip()
+
+
+def interactive_loop(client: OpenAI, prompt_template: str, model: str) -> None:
+    """Start an interactive REPL for querying motions."""
+    try:
+        while True:
+            query = input("Describe motion> ").strip()
+            if not query or query.lower() in {"exit", "quit"}:
+                break
+            result = ask_motion(client, prompt_template, model, query)
+            print("Motion:", result)
+    except KeyboardInterrupt:
+        pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Query ChatGPT for Vim motions.")
+    parser.add_argument("description", nargs="*", help="Task description. If omitted, start interactive shell.")
+    parser.add_argument("--model", default="gpt-4.1", help="OpenAI model to use (default: gpt-4.1)")
+    parser.add_argument("--prompt-file", default="extended_prompt.txt", help="Path to extended prompt template")
+    parser.add_argument("--api-key", default=os.environ.get("OPENAI_API_KEY"), help="OpenAI API key")
+    args = parser.parse_args()
+
+    if args.api_key is None:
+        parser.error("OpenAI API key required via --api-key or OPENAI_API_KEY")
+
+    with open(args.prompt_file, "r", encoding="utf-8") as f:
+        prompt_template = f.read()
+
+    client = OpenAI(api_key=args.api_key)
+
+    if args.description:
+        description = " ".join(args.description)
+        print(ask_motion(client, prompt_template, args.model, description))
+    else:
+        interactive_loop(client, prompt_template, args.model)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `vim_motion_cli.py` for querying ChatGPT 4.1 using the extended prompt
- document the new CLI usage in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844c5ad49a48326a4ec2ebf0362919d